### PR TITLE
Update LoadBalancingRouterProxyClient.java

### DIFF
--- a/src/main/java/io/undertow/server/handlers/proxy/LoadBalancingRouterProxyClient.java
+++ b/src/main/java/io/undertow/server/handlers/proxy/LoadBalancingRouterProxyClient.java
@@ -153,7 +153,6 @@ public class LoadBalancingRouterProxyClient implements ProxyClient {
     public synchronized void addHosts(final String serviceId, final String envTag) {
         String key = serviceId + envTag;
         List<URI> uris = cluster.services(ssl == null ? "http" : "https", serviceId, envTag);
-        hosts.remove(key);
         Host[] newHosts = new Host[uris.size()];
         for (int i = 0; i < uris.size(); i++) {
             Host h = new Host(serviceId, bindAddress, uris.get(i), ssl, options);


### PR DESCRIPTION
Fix issue #1607 in the 1.6.x branch. The code is in light-4j for 2.0.x. This issue will return a 503 error if the server has CPU and memory constraints. It is only exposed when the downstream API is slow and there are a lot of pressures put on the light-router. 

https://github.com/networknt/light-4j/issues/1607